### PR TITLE
Gateway Registration Handling

### DIFF
--- a/sms_registration.py
+++ b/sms_registration.py
@@ -20,8 +20,9 @@ def register(push_token: bytes, no_parse = False, gateway = None) -> tuple[str, 
         print("MCC+MNC received! " + mccmnc)
         print("Determining gateway...")
         gateway = gateway_fetch.getGatewayMCCMNC(mccmnc)
+    if gateway is not None:
         print("Gateway found!  " + str(gateway))
-    if gateway is None:
+    else:
         print("Automatic gateway detection failed, switching to default...")
         gateway = GATEWAY
     token = push_token.hex().upper()

--- a/sms_registration.py
+++ b/sms_registration.py
@@ -20,7 +20,7 @@ def register(push_token: bytes, no_parse = False, gateway = None) -> tuple[str, 
         print("MCC+MNC received! " + mccmnc)
         print("Determining gateway...")
         gateway = gateway_fetch.getGatewayMCCMNC(mccmnc)
-        print("Gateway found!  " + gateway)
+        print("Gateway found!  " + str(gateway))
     if gateway is None:
         print("Automatic gateway detection failed, switching to default...")
         gateway = GATEWAY

--- a/sms_registration.py
+++ b/sms_registration.py
@@ -23,8 +23,9 @@ def register(push_token: bytes, no_parse = False, gateway = None) -> tuple[str, 
     if gateway is not None:
         print("Gateway found!  " + str(gateway))
     else:
-        print("Automatic gateway detection failed, switching to default...")
-        gateway = GATEWAY
+        print("No gateway was provided, and automatic gateway detection failed. Please run again with the --gateway flag.")
+        # gateway = GATEWAY
+        raise
     token = push_token.hex().upper()
     req_id = random.randint(0, 2**32)
     sms = f"REG-REQ?v=3;t={token};r={req_id};"


### PR DESCRIPTION
This commit does these things:

1. When no gateway is provided and automatic gateway registration fails, a better descriptive error occurs rather than a "Nonetype error".
2. Print statements are in order so it doesn't say "success" then fails
3. Yeah that's really it (approved by spacesaver2000)