### PR TITLE
Sms registration

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -290,7 +290,7 @@ async def input_task(im: imessage.iMessageUser):
     while True:
         cmd = await trio.to_thread.run_sync(input, "> ", cancellable=True)
         if cmd != "":
-            await im.send(imessage.iMessage.create(im, cmd, ["tel:+13158824630"]))
+            await im.send(imessage.iMessage.create(im, cmd, ["tel:+16106632676"]))
 
 async def output_task(im: imessage.iMessageUser):
     while True:


### PR DESCRIPTION
-Corrected an oversight where not all the data from config.json was being updated with the current information after --reregister was run.
-When --reregister is run it will now print out the date/time that the number registration is valid until.
-Added an argument, --reg-notify, so you can receive an iMessage after each reregistration telling you when the number registration is valid until. You would run "demo.py --reregister --reg-notify", if you don't want to be notified you can simply keep running "demo.py --reregister".