### PR TITLE
Create and activate venv before installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ It can currently register as a new device on an Apple ID, set up encryption keys
 
 ## Installation
 It's pretty self explanatory:
-1. `git clone https://github.com/JJTech0130/pypush`
+1. `git clone https://github.com/JJTech0130/pypush && cd pypush`
 2. `python3 -m venv venv && source venv/bin/activate`
 3. `pip3 install -r requirements.txt`
-5. `python3 ./demo.py`
+4. `python3 ./demo.py`
 
 ## Troubleshooting
 If you have any issues, please join [the Discord](https://discord.gg/BVvNukmfTC) and ask for help.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ It can currently register as a new device on an Apple ID, set up encryption keys
 ## Installation
 It's pretty self explanatory:
 1. `git clone https://github.com/JJTech0130/pypush`
-2. `pip3 install -r requirements.txt`
-3. `python3 ./demo.py`
+2. `python3 -m venv venv && source venv/bin/activate`
+3. `pip3 install -r requirements.txt`
+5. `python3 ./demo.py`
 
 ## Troubleshooting
 If you have any issues, please join [the Discord](https://discord.gg/BVvNukmfTC) and ask for help.


### PR DESCRIPTION
Using a Python 'venv' will install all dependencies within the virtual environment. This will reduce clutter on the users system and does not impact functionality in any way.

Also, I added the `cd` step.