### PR TITLE
Termux: Add termux_installer.sh and include README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is the Pypush sms-registration branch. This branch allows you to register y
 
 sms-registration is not fully developed yet, and still contains bugs! If you encounter any sort of bug, please join [our Discord](https://discord.gg/BtSbcExKJ9), however please note we cannot get to everyone, so try to figure out any errors yourself before asking.
 
-***Please note:*** You will have to use a client to send messages from your phone. We recommend [Beeper](https://www.beeper.com/), which is the best solution to keep all your chat apps inside one place, including iMessage! You can also use [BlueBubbles](https://bluebubbles.app/) (which requires you to have a server Mac running 24/7). One of our community members is also currently working on a BlueBubbles fork that implements a version of Pypush within it, so no server is needed and number reregistration is automatically ran.
+***Please note:*** You will have to use a client to send messages from your phone. We recommend [Beeper](https://www.beeper.com/), which is the best solution to keep all your chat apps inside one place, including iMessage! You can also use [BlueBubbles](https://bluebubbles.app/) (which requires you to have a server Mac running 24/7). One of our community members is also currently working on a BlueBubbles fork that implements a version of Pypush within it, so no server is needed and number reregistration is automatically ran.  Additionally, Beeper has a more complete proprietary paid Android app solution derived from this Pypush PoC named [Beeper Mini](https://blog.beeper.com/p/introducing-beeper-mini-get-blue) ([details](https://blog.beeper.com/p/how-beeper-mini-works)) that includes both the messaging app and the registration.  
 
 However, Beeper is completely free and easy to use, and comes packed with multiple features that rivals native apps. Beeper is currently in the process of removing the waitlist, so you will have to use an invite link shared to you in order to skip the waitlist until this change is made. This app is what most testing is done on, and is by far the most popular in the Android and iMessage community.
 
@@ -13,21 +13,113 @@ You will first install Pypush onto your machine. *Please keep in mind that you w
 ### PNRgateway
 In order for Apple to verify your number, a specialized message has to be sent from your phone to Apple's "gateway number" and have the response captured. This number is different for each carrier, however the newest app version should automatically find your gateway number. If PNRgateway cannot find your gateway number, see below for help.
 
-1. Enable USB debugging/ADB on your phone. There are multiple online guides that guide you through this based on your phone.
-2. Install the APK. The message link containing the APK is located [here](https://discord.com/channels/1130633272595066880/1145177252015915080/1153070972090470481), and the GitHub repository is [here](https://github.com/JJTech0130/PNRGatewayClientV2).
-3. Grant SMS permissions. This will be in the app info page, and on the newer version, there should be a button in the app that does this for you.
-4. Connect your phone to the same WiFi network as your host PC, and open the app.
+1. Install the APK. The message link containing the APK is located [here](https://discord.com/channels/1130633272595066880/1145177252015915080/1153070972090470481), and the GitHub repository is [here](https://github.com/JJTech0130/PNRGatewayClientV2).
+2. Open the app.
+3. Grant SMS permissions by clicking the button and approving the permissions.
+4. Connect your phone to the same WiFi network as your host PC, and open the app (unless using Android: Termux, then it doesn't matter what network)
 
 ### Pypush
 Once you have the PNRgateway app installed on your phone, open it so it is displaying your IP address as you will need it for the next steps. 
 
-Use one of the automated installers for your operating system: [Windows](https://github.com/JJTech0130/pypush/blob/bacefed8b8eb78d5d3f295be5304830665464a04/windows_installer.ps1) or [MacOS/Linux](https://github.com/JJTech0130/pypush/blob/bacefed8b8eb78d5d3f295be5304830665464a04/unix_installer.sh)
-
-For Windows open up PowerShell and navigate to your downloads folder `cd Downloads` and then execute the installer `.\windows_installer.ps1` and follow the prompts. When initial registration has completed execute the file `windows_reregister.ps1` to handle reregistration. This file will reregister your number 5 minutes before registration expires and you must keep the PowerShell window open. Length of registration will gradually increase. 
-
-For MacOS/Linux open up your terminal and navigate to your downloads folder `cd Downloads` or similar. Make the script executable by executing `chmod +x unix_installer.sh`. Execute the script `./unix_installer.sh`. Upon completion a shell script is created called `reregister.sh`. Execute this script in your terminal `./reregister.sh`. This file will reregister your number 5 minutes before registration expires and you must keep the terminal window open. Length of registration will gradually increase.
+Use one of the automated installers for your operating system: [Windows](https://github.com/JJTech0130/pypush/blob/bacefed8b8eb78d5d3f295be5304830665464a04/windows_installer.ps1), [MacOS/Linux](https://github.com/JJTech0130/pypush/blob/bacefed8b8eb78d5d3f295be5304830665464a04/unix_installer.sh), or [Android Termux](./termux_installer.sh).  
 
 If you need help or run into errors please reach out on our [Discord](https://discord.gg/BtSbcExKJ9) server.
+
+#### Windows
+
+1. Open up Powershell and navigate to your downloads folder
+
+```powershell
+cd Downloads
+```
+
+2. Execute the installer
+
+```powershell
+.\windows_installer.ps1
+```
+
+3. Follow the prompts
+4. Once initial registration has completed successfully, execute the reregistration setup file
+
+```powershell
+windows_reregistration.ps1
+```
+
+This file will re-register your number 5 minutes before registration expires.  
+
+5. Leave the Powershell window open permanently
+
+The length of your registration will gradually increase the longer the reregistration process runs.
+
+##### MacOS/Linux
+
+1. Open up your temrinal and navigate to your downloads folder
+
+```shell
+cd Downloads
+```
+
+2. Make the script executable
+
+```shell
+chmod +x unix_installer.sh
+```
+
+3. Execute the script
+
+```shell
+./unix_installer.sh
+```
+
+4. Once initial registration has completed successfully, a `reregister.sh` script is created.
+5. Execute the reregistration script
+
+```shell
+./reregister.sh
+```
+
+This will reregister your number 5 minutes before registration expires.  
+
+6. Leave the terminal window open permanently
+
+The length of your registration will gradually increase the longer the reregistration process runs.
+
+##### Android Termux
+
+This solution should be run on the same mobile device as the PNRGateway, and greatly simplifies the Pypush to PNRGateway connection required during initial setup.  
+
+1. Ensure you have [`Termux`](https://f-droid.org/en/packages/com.termux/) and [`Termux: API`](https://f-droid.org/en/packages/com.termux.api/) apps installed from F-Droid.  
+**The Google Play `Termux` app is not updated, and is incompatible with the `Termux: API` app that's only available on F-Droid.**  
+2. Download the `termux_installer.sh` script above onto your phone.
+3. Open `Termux`
+4. Grant storage permissions to `Termux`
+
+```shell
+termux-setup-storage
+```
+
+And accept the permissions prompt for all files.  
+
+5. Open the `PNRGateway` app on a split screen.  
+**The `PNRGateway` app must be open in the foreground at the same time as `Termux` for it to function correctly.**  
+
+6. Set the permissions on the script
+
+```shell
+chmod +x /storage/emulated/0/Download/termux_installer.sh
+```
+
+7. Execute the script
+
+```shell
+/storage/emualted/0/Download/termux_installer.sh
+```
+
+8. You will be walked thru the steps to register your phone number, create `~/pypush/reregistration.sh`, and setup a persistent system job to run the reregistration automatically.
+9. If the registration indicates Apple has given you an expiration time of less than 15 minutes, you will need to manually run the `~/pypush/reregistration.sh` script about 5 minutes before expiration. Android system jobs are not able to be run more frequently than 15 minutes.
+
+The length of your registration will gradually increase the longer the reregistration process runs.
 
 ### Pypush Manual Installation
 Make sure you have git and Python installed.

--- a/termux_installer.sh
+++ b/termux_installer.sh
@@ -1,0 +1,146 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+set -o pipefail
+
+die() {
+	[ $# -eq 0 ] || echo >&2 "ERROR: " "$@"
+	exit 1
+}
+
+# verify we're on Android (though the #! line at the top will only work in a termux terminal anyway)
+[[ "$(uname -o)" == "Android" ]] || die "This installer only works when run on Android"
+
+set -x
+# make sure all our existing pkgs are updated
+pkg up || die "Updating all packages"
+
+# install things from the pkg repo
+#  python-cryptography:
+#      Has to be installed from pkg rather than from pip3 because installing it from pip3
+#      doesn't find a pre-built binary, and the termux Rust toolchain for the fallback
+#      building it from source doesn't work without tons of effort. That's why it's pre-packaged
+#      by pkg.
+#  build-essential:
+#      The python unicorn package doens't have a compatible pre-build binary version in PyPi
+#      so it will build it from source on-demand.  That requires the build-essential tools,
+#      like gcc, cmake, etc.
+pkg install \
+	termux-tools \
+	termux-api \
+	python \
+	python-cryptography \
+	python-pip \
+	git \
+	build-essential \
+	binutils
+  || die "Installing necessary packages"
+
+set +x
+
+# verify the termux-api actually works. if 
+timeout -s 9 30s termux-job-scheduler -p \
+	|| die "Unable to use termux API, verify the it and the Termux app are both installed and both from F-Droid (not Google Play)"
+
+# Because we can't build the python 'cryptography' library on Termux, we can't install it in a venv.
+# That means we have to install all the packages directly on the host instead.
+
+# Clone the repo
+cd $HOME
+set -x
+git clone -b sms-registration https://github.com/JJTech0130/pypush \
+	|| die
+set +x
+cd pypush
+
+set -x
+# Install dependencies
+pip3 install -r requirements.txt \
+	|| die
+# on Termux, this isn't automatically installed with pip so it's not provided by pkg like the requirements.txt expects
+pip3 install setuptools \
+	|| die
+set +x
+
+read -p "Make sure the PNRGateway app ("Pypush SMS Registration Hellper") is running in split screen, then press Enter" JUNK
+
+remove_config_json() {
+	rm -f $HOME/pypush/config.json
+}
+export -f remove_config_json
+
+if [ -e "$HOME/pypush/config.json" ]; then
+	read -p "Remove existing config.json file? (Y/n) " REMOVE_IT
+	# lowercase it and drop anything that's not 'y' or 'n'
+	REMOVE_IT=$(echo -n "$REMOVE_IT" | tr '[:upper:]' '[:lower:]' | tr -dc 'yn' )
+	if [[ "$REMOVE_IT" != "n" ]]; then
+		echo "Removing prior config.json"
+		set -x
+		rm $HOME/pypush/config.json
+		set +x
+	fi
+fi
+
+# set a trap to remove the config.json file if the next step fails
+trap "remove_config_json" EXIT
+
+set -x
+# Execute the `python demo.py` script.  Since we're in Termux, the app is on localhost relative to us.
+# This is user-interactive
+python3 demo.py --phone 127.0.0.1 \
+	|| die "If registering with the number failed, it might be a temporary carrier issue, but confirm the registration number for your carrier was used from this list: https://discord.com/channels/1130633272595066880/1130990221920575618/1154069380699791470"
+set +x
+trap "" EXIT
+
+echo "Creating reregistration.sh" script
+
+# Create a reregistration script
+cat > reregister.sh <<EOF
+#!/data/data/com.termux/files/usr/bin/bash
+cd $HOME/pypush
+# When unlocking, or powering on the phone, the job may trigger multiple times.
+# Protect it from parallel execution (sort of) with a simple flag file existence check.
+flag=reregistering.flag
+if [ ! -e \$flag ]; then
+	touch \$flag
+	# use --cronreg so it only reregisters if it's going to expire in the next 60 minutes
+	python3 ./demo.py --cronreg
+	ret=\$?
+	rm \$flag
+	exit \$ret
+fi
+EOF
+[ $? -eq 0 ] || die "Creating reregistrater.sh"
+
+# Make the file executable
+chmod +x reregister.sh \
+	|| die "Adding execute permissions to regristrater.sh"
+
+# Setup the reregistration as an Android system job.
+job_reg_args=()
+job_reg_args+=("--script" "$(pwd)/reregister.sh")
+# The minimum period allowed is 15 min (900000 ms).
+job_reg_args+=("--period-ms" "900000")
+# Even if the battery is low, we need to re-register to maintain the phone number link.
+job_reg_args+=("--battery-not-low" "false")
+# Make it permanent across reboots too.
+job_reg_args+=("--persisted" "true")
+
+echo "Checking for prior scheduled regregistration job"
+
+# in case the scheduled job was already setup to run our scrip previously,
+# query the termux job scheduler, grep for our script, split on : taking the first, then split on spaces taking the third
+# to get the job ID(s) from the pending list.  Take only the first job if there's more than one, and strip the newline
+# so we have just the number.  If any of this fails, just return blank with no newline.
+existing_job_id=$(termux-job-scheduler -p | grep "reregister\.sh" | cut -d ':' -f1 | cut -d ' ' -f3 | head -n1 | tr -d '\n' || echo -n "")
+
+if [ -n "$existing_job_id" ]; then
+	echo "Scheduled job for reregistration already exists with ID: $existing_job_id"
+	job_reg_args+=("--job-id" "$existing_job_id")
+fi
+
+echo "Scheduling reregistration job"
+set -x
+# schedule it, or update the pre-existing scheduled job
+termux-job-scheduler "${job_reg_args[@]}" \
+	|| die "Scheduling re-registration as an Android system job"
+set +x


### PR DESCRIPTION
Adds `termux_installer.sh` to setup pypush SMS registration and schedule it as a persistent Android job to run re-registration.  

Added the Termux installation instruction to the README, and converted the other existing ones to an ordered list instead.  

Made reference to Beeper Mini that can be used as a paid proprietary stand alone alternative.