### PR TITLE
Fix reconnection with a cached base token

### DIFF
--- a/pypush/apns/lifecycle.py
+++ b/pypush/apns/lifecycle.py
@@ -76,8 +76,7 @@ class Connection:
 
     @property
     async def base_token(self) -> bytes:
-        if self._base_token is None:
-            await self._connected.wait()
+        await self._connected.wait()
         assert self._base_token is not None
         return self._base_token
 
@@ -134,25 +133,21 @@ class Connection:
 
             self._tg.start_soon(self._receive_task)
             ack = await self._receive(
-                filters.chain(
-                    filters.cmd(protocol.ConnectAck),
-                    lambda c: (
-                        c
-                        if (
-                            c.token == self._base_token
-                            if self._base_token is not None
-                            else True
-                        )
-                        else None
-                    ),
-                )
+                filters.cmd(protocol.ConnectAck),
             )
             logging.debug(f"Connected with ack: {ack}")
             assert ack.status == 0
-            if self._base_token is None:
+            if ack.token is None:
+                # Server accepted the cached token without returning a new one
+                logging.debug(f"Base token accepted by server: {self._base_token.hex()}")
+            elif self._base_token is None:
+                self._base_token = ack.token
+                logging.debug(f"Base token assigned: {ack.token.hex()}")
+            elif ack.token != self._base_token:
+                logging.warning(f"Base token changed: {self._base_token.hex()} -> {ack.token.hex()}")
                 self._base_token = ack.token
             else:
-                assert ack.token == self._base_token
+                logging.debug(f"Base token confirmed: {ack.token.hex()}")
             if not self._connected.is_set():
                 self._connected.set()
 


### PR DESCRIPTION
## Summary

- Fix `_receive` hanging forever when reconnecting with a pre-cached `base_token`, caused by the `ConnectAck` filter requiring an exact token match
- Fix crash when server accepts the cached token without returning one in `ConnectAck` (`ack.token` is `None`)
- Fix race condition where `base_token` property returned before the TCP connection was established

## Background

When the `token` parameter is passed to `create_apns_connection` (e.g. restoring a previously persisted token), three things go wrong:

1. The `ConnectAck` receive filter checks `c.token == self._base_token`. But the server may return a *different* token, or **omit the token field entirely** (item `0x03` absent) when it accepts the cached one. This causes `_receive` to wait forever.

2. The `base_token` property skips `_connected.wait()` when `_base_token` is already set, so callers can attempt to send commands before `_conn` is initialized.

3. `assert ack.token == self._base_token` crashes when `ack.token is None`.

This matches real `apsd` behavior: the daemon persists the base token to `com.apple.apsd.plist` and sends it on reconnect (e.g. after a device reboot). The server typically accepts it silently.